### PR TITLE
More lint

### DIFF
--- a/site/eslint.config.mjs
+++ b/site/eslint.config.mjs
@@ -56,6 +56,7 @@ export default tseslint.config(
     },
   },
   ...tseslint.configs.strictTypeChecked,
+  ...tseslint.configs.stylisticTypeChecked,
   {
     plugins: {
       "eslint-comments": eslintComments,
@@ -104,6 +105,19 @@ export default tseslint.config(
         },
       ],
       "eslint-comments/require-description": ["error"],
+      // interfaces are not perfectly substitutable for types so don't prefer
+      // them
+      "@typescript-eslint/consistent-type-definitions": ["error", "type"],
+    },
+  },
+  {
+    // Type definitions are constrained by external libraries and won't always
+    // pass linting
+    files: ["**/*.d.ts"],
+    rules: {
+      "@typescript-eslint/no-unused-vars": ["off"],
+      "@typescript-eslint/consistent-type-definitions": ["off"],
+      "@typescript-eslint/no-explicit-any": ["off"],
     },
   },
   {
@@ -116,7 +130,7 @@ export default tseslint.config(
     },
     linterOptions: {
       reportUnusedDisableDirectives: true,
-    }
+    },
   },
   {
     // Don't do type-checking on any plain .js files in the tree.
@@ -129,8 +143,6 @@ export default tseslint.config(
     ignores: [
       // Don't lint generated stuff under dist/
       "dist/*",
-      // nor our additional (usually external) type signatures
-      "types/mfng/*.ts",
       // nor the unused config
       "node-webpack.config.mjs",
     ],

--- a/site/knexfile.ts
+++ b/site/knexfile.ts
@@ -2,7 +2,7 @@ import type { Knex } from "knex";
 
 // Update with your config settings.
 
-const config: { [key: string]: Knex.Config } = {
+const config: Record<string, Knex.Config> = {
   memory: {
     client: "better-sqlite3",
     connection: {
@@ -33,7 +33,7 @@ const config: { [key: string]: Knex.Config } = {
     // N.B. pg has a very different idea of a "connection string" than libpq :(
     // Refer to the source: https://github.com/brianc/node-postgres/blob/master/packages/pg-connection-string/index.js
     connection:
-      process.env.DB_URI || "postgresql:///hunt2025?host=/run/postgresql",
+      process.env.DB_URI ?? "postgresql:///hunt2025?host=/run/postgresql",
     pool: {
       min: 2,
       max: 10,
@@ -45,7 +45,7 @@ const config: { [key: string]: Knex.Config } = {
     // N.B. pg has a very different idea of a "connection string" than libpq :(
     // Refer to the source: https://github.com/brianc/node-postgres/blob/master/packages/pg-connection-string/index.js
     connection:
-      process.env.DB_URI || "postgresql:///hunt2025?host=/run/postgresql",
+      process.env.DB_URI ?? "postgresql:///hunt2025?host=/run/postgresql",
     pool: {
       min: 2,
       max: 10,

--- a/site/lib/api/client.tsx
+++ b/site/lib/api/client.tsx
@@ -4,7 +4,7 @@ import { contract } from "./contract";
 export function newClient(baseUrl: string, token?: string) {
   const baseHeaders: Record<string, string> = {};
   if (token) {
-    baseHeaders["Authorization"] = "bearer " + token;
+    baseHeaders.Authorization = "bearer " + token;
   }
   return initClient(contract, {
     baseUrl: baseUrl + "/api",

--- a/site/playwright.config.ts
+++ b/site/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: huntBaseURL || "http://127.0.0.1:3000",
+    baseURL: huntBaseURL ?? "http://127.0.0.1:3000",
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",

--- a/site/src/api/db.ts
+++ b/site/src/api/db.ts
@@ -79,41 +79,41 @@ export async function connect(environment: string) {
 }
 
 declare module "knex/types/tables" {
-  interface Team {
+  type Team = {
     username: string;
     password?: string;
-  }
+  };
 
-  interface TeamRound {
+  type TeamRound = {
     username: string;
     slug: string;
     unlocked: boolean;
-  }
+  };
 
-  interface TeamPuzzle {
+  type TeamPuzzle = {
     username: string;
     slug: string;
     visible: boolean;
     unlockable: boolean;
     unlocked: boolean;
     solved: boolean;
-  }
+  };
 
-  interface TeamPuzzleGuess {
+  type TeamPuzzleGuess = {
     username: string;
     slug: string;
     canonical_input: string;
     timestamp: Date;
     correct: boolean;
     response?: string;
-  }
+  };
 
-  interface TeamInteraction {
+  type TeamInteraction = {
     username: string;
     id: string;
     unlocked: boolean;
     completed: boolean;
-  }
+  };
 
   type InsertActivityLogEntry = {
     username?: string;
@@ -156,6 +156,10 @@ declare module "knex/types/tables" {
     currency_delta: number;
   } & InsertActivityLogEntry;
 
+  /* eslint-disable-next-line @typescript-eslint/consistent-type-definitions --
+   * This must be defined as an interface as it's extending a declaration from
+   * knex
+   */
   interface Tables {
     teams: Team;
     team_rounds: TeamRound;
@@ -210,7 +214,7 @@ export async function getTeamState(team: string, trx: Knex.Knex.Transaction) {
         .orWhere("username", null)
         .sum({ sum: "currency_delta" })
         .first()
-    )?.sum || 0,
+    )?.sum ?? 0,
   );
   return {
     available_currency,
@@ -306,7 +310,7 @@ export async function recalculateTeamState(
         .where("correct", true)
         .count("*", { as: "count" })
         .groupBy("slug")
-    ).map(({ slug, count }) => [slug, Number(count || 0)]),
+    ).map(({ slug, count }) => [slug, Number(count ?? 0)]),
   );
   console.log(interactions_completed);
   console.log(puzzle_solution_count);

--- a/site/src/api/server.tsx
+++ b/site/src/api/server.tsx
@@ -40,7 +40,7 @@ type JWTPayload = {
 };
 
 function cookieExtractor(req: Request) {
-  const token = req.cookies["mitmh2025_auth"] as string | undefined;
+  const token = req.cookies.mitmh2025_auth as string | undefined;
   return token ? token : null;
 }
 
@@ -130,7 +130,7 @@ export function getRouter({
         [...data.visible_puzzles].map((slug) => [
           slug,
           {
-            round: puzzleRounds[slug] || "outlands", // TODO: Should this be hardcoded?
+            round: puzzleRounds[slug] ?? "outlands", // TODO: Should this be hardcoded?
             locked: data.unlocked_puzzles.has(slug)
               ? "unlocked"
               : data.unlockable_puzzles.has(slug)
@@ -177,7 +177,7 @@ export function getRouter({
       locked,
       guesses: guesses.map(({ canonical_input, response, timestamp }) => ({
         canonicalInput: canonical_input,
-        response: response || "",
+        response: response ?? "",
         timestamp: timestamp.toISOString(),
       })),
     };
@@ -338,7 +338,7 @@ export function getRouter({
                   username: team,
                   slug,
                   type: "puzzle_solved",
-                  currency_delta: correct_answer.prize || 0,
+                  currency_delta: correct_answer.prize ?? 0,
                   data: {
                     answer: canonical_input,
                   },

--- a/site/src/frontend/components/Layout.tsx
+++ b/site/src/frontend/components/Layout.tsx
@@ -113,8 +113,7 @@ const Layout = ({
     <html lang="en">
       <head>
         {title && <title>{title}</title>}
-        {stylesheets &&
-          stylesheets.map((s) => <link key={s} rel="stylesheet" href={s} />)}
+        {stylesheets?.map((s) => <link key={s} rel="stylesheet" href={s} />)}
       </head>
       <body>
         <div
@@ -128,8 +127,7 @@ const Layout = ({
           <div style={{ flex: 1 }}>{children}</div>
           {renderDevPane(teamState)}
         </div>
-        {scripts &&
-          scripts.map((s) => <script key={s} type="text/javascript" src={s} />)}
+        {scripts?.map((s) => <script key={s} type="text/javascript" src={s} />)}
       </body>
     </html>
   );

--- a/site/src/frontend/components/RoundPuzzleList.tsx
+++ b/site/src/frontend/components/RoundPuzzleList.tsx
@@ -20,7 +20,7 @@ const RoundPuzzleList = ({
     const slug = slots[slot];
     const puzzleState = slug ? puzzleStates[slug] : undefined;
     const puzzleDefinition = slug ? PUZZLES[slug] : undefined;
-    const title = puzzleDefinition?.title || `Stub puzzle for slot ${slot}`;
+    const title = puzzleDefinition?.title ?? `Stub puzzle for slot ${slot}`;
     let item;
     if (puzzleState?.locked === "locked") {
       item = (

--- a/site/src/frontend/rounds/shadow_diamond/index.tsx
+++ b/site/src/frontend/rounds/shadow_diamond/index.tsx
@@ -4,7 +4,7 @@ import photoimage from "../../../assets/demo-photo.png";
 import RoundPuzzleList from "../../components/RoundPuzzleList";
 
 const ShadowDiamondRoundPage = ({ teamState }: { teamState: TeamState }) => {
-  const roundState = teamState.rounds["shadow_diamond"];
+  const roundState = teamState.rounds.shadow_diamond;
   if (roundState === undefined) {
     return undefined;
   }

--- a/site/src/frontend/server/routes.tsx
+++ b/site/src/frontend/server/routes.tsx
@@ -59,7 +59,7 @@ const loginPostHandler: RequestHandler<
     res.status(500).send("Internal server error");
     return;
   }
-  const qs = req.query["next"];
+  const qs = req.query.next;
   // Don't bother with weird query string formats.  Get a string, or get your
   // next path ignored.
   const target = qs && typeof qs === "string" ? qs : "/";
@@ -128,7 +128,7 @@ export function getUiRouter({ apiUrl }: { apiUrl: string }) {
   unauthRouter.use((req: Request, _res: Response, next: NextFunction) => {
     req.api = newClient(
       apiUrl,
-      req.cookies["mitmh2025_auth"] as string | undefined,
+      req.cookies.mitmh2025_auth as string | undefined,
     );
     next();
   });
@@ -138,7 +138,7 @@ export function getUiRouter({ apiUrl }: { apiUrl: string }) {
     asyncHandler(async (req: Request, res: Response, next: NextFunction) => {
       req.api = newClient(
         apiUrl,
-        req.cookies["mitmh2025_auth"] as string | undefined,
+        req.cookies.mitmh2025_auth as string | undefined,
       );
       const teamStateResp = await req.api.public.getMyTeamState();
       if (teamStateResp.status === 401) {

--- a/site/src/huntdata/logic.ts
+++ b/site/src/huntdata/logic.ts
@@ -1,15 +1,15 @@
 import type { Hunt, Condition, PuzzleSlot } from "./types";
 
-interface ConditionState {
+type ConditionState = {
   hunt: Hunt;
   interactions_completed: Set<string>;
   puzzle_solution_count: Record<string, number>;
-}
+};
 
-interface ConditionStateInternal extends ConditionState {
+type ConditionStateInternal = {
   current_round?: string;
   slug_by_slot: Record<string, string>;
-}
+} & ConditionState;
 
 function evaluateCondition(
   condition: Condition,
@@ -41,7 +41,7 @@ function evaluateCondition(
   }
   if ("slug_solved" in condition) {
     const { slug_solved, answer_count } = condition;
-    return (puzzle_solution_count[slug_solved] || 0) >= (answer_count || 1);
+    return (puzzle_solution_count[slug_solved] ?? 0) >= (answer_count ?? 1);
   }
   if ("puzzles_solved" in condition) {
     const { puzzles_solved } = condition;
@@ -69,7 +69,7 @@ function evaluateCondition(
 
 export function getSlotSlug(slot: PuzzleSlot) {
   return (
-    slot.slug ||
+    slot.slug ??
     ((process.env.NODE_ENV == "development" ||
       process.env.NODE_ENV == "test") &&
       slot.id)
@@ -95,10 +95,10 @@ export function getSlugsBySlot(hunt: Hunt) {
 export function calculateTeamState(condition_state: ConditionState) {
   const { hunt } = condition_state;
 
-  const unlocked_rounds: Set<string> = new Set();
-  const visible_puzzles: Set<string> = new Set();
-  const unlockable_puzzles: Set<string> = new Set();
-  const unlocked_puzzles: Set<string> = new Set();
+  const unlocked_rounds = new Set<string>();
+  const visible_puzzles = new Set<string>();
+  const unlockable_puzzles = new Set<string>();
+  const unlocked_puzzles = new Set<string>();
 
   const slug_by_slot = getSlugsBySlot(hunt);
 

--- a/site/src/main.ts
+++ b/site/src/main.ts
@@ -4,8 +4,8 @@ import app from "./app";
 const port = 3000;
 
 // N.B. process.env.NODE_ENV is compiled by webpack
-const environment = process.env.NODE_ENV || "development";
-const db_environment = process.env.DB_ENV || "development";
+const environment = process.env.NODE_ENV ?? "development";
+const db_environment = process.env.DB_ENV ?? "development";
 let jwt_secret: string | Buffer | undefined = process.env.JWT_SECRET;
 if (environment == "development" && !jwt_secret) {
   jwt_secret = randomBytes(128);

--- a/site/types/mfng/react-server-dom-webpack-server.d.ts
+++ b/site/types/mfng/react-server-dom-webpack-server.d.ts
@@ -20,7 +20,7 @@ declare module 'react-server-dom-webpack/server.edge' {
     | boolean
     | number
     | null
-    | ReadonlyArray<ServerContextJSONValue>
+    | readonly ServerContextJSONValue[]
     | {[key: string]: ServerContextJSONValue};
 
   export function renderToReadableStream(

--- a/site/types/mfng/react-server-dom-webpack.d.ts
+++ b/site/types/mfng/react-server-dom-webpack.d.ts
@@ -1,33 +1,25 @@
-declare module 'react-server-dom-webpack' {
+declare module "react-server-dom-webpack" {
   import type {
     Component,
     Context,
     LazyExoticComponent,
     ReactElement,
-  } from 'react';
+  } from "react";
 
-  export interface ClientManifest {
-    [id: string]: ImportManifestEntry;
-  }
+  export type ClientManifest = Record<string, ImportManifestEntry>;
 
-  export interface ServerManifest {
-    [id: string]: ImportManifestEntry;
-  }
+  export type ServerManifest = Record<string, ImportManifestEntry>;
 
   export interface SSRManifest {
     moduleMap: SSRModuleMap;
     moduleLoading: ModuleLoading | null;
   }
 
-  export interface SSRModuleMap {
-    [clientId: string]: {
-      [clientExportName: string]: ImportManifestEntry;
-    };
-  }
+  export type SSRModuleMap = Record<string, Record<string, ImportManifestEntry>>;
 
   export interface ModuleLoading {
     prefix: string;
-    crossOrigin?: 'use-credentials' | '';
+    crossOrigin?: "use-credentials" | "";
   }
 
   export interface ImportManifestEntry {
@@ -61,13 +53,14 @@ declare module 'react-server-dom-webpack' {
     | number
     | symbol
     | null
-    | void
+    | undefined
     | Iterable<ReactClientValue>
     | ReactClientValue[]
     | ReactClientObject
     | Promise<ReactClientValue>; // Thenable<ReactClientValue>
 
-  export type ReactClientObject = {[key: string]: ReactClientValue};
+  /* eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style -- Need an index signature to support recursion */
+  export type ReactClientObject = { [key: string]: ReactClientValue };
 
   // Serializable values for the server
   export type ReactServerValue =
@@ -80,11 +73,12 @@ declare module 'react-server-dom-webpack' {
     | number
     | symbol
     | null
-    | void
+    | undefined
     | Iterable<ReactServerValue>
     | ReactServerValue[]
     | ReactServerObject
     | Promise<ReactServerValue>; // Thenable<ReactServerValue>
 
-  export type ReactServerObject = {[key: string]: ReactServerValue};
+  /* eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style -- Need an index signature to support recursion */
+  export type ReactServerObject = { [key: string]: ReactServerValue };
 }


### PR DESCRIPTION
Most of the changes here are to support tseslint's "stylistic" checks. Here's what I said in the commit message about including those:

> Enable tseslint's stylistic checks
> 
> I like these for encouraging consistency across the codebase and for
> generally encouraging a single right way to write things, although they
> can have a slightly higher false positive rate. The changes they applied
> to our code are mostly:
> 
> * Consistently using `type` declarations instead of `interface`
>   declarations. The tseslint default is to prefer interfaces, but they
>   don't satisfy assignability in certain cases (e.g. to a broader
>   Record<string, unknown> type). There are a few places where we need to
>   use interfaces for their reopenability; those get lint disables
> * Prefer the nullish coalescing operator (`??`) over logical or (`||`).
>   I like this rule because it avoids issues of falsiness in Javascript
>   (but does mean there are a few cases where, e.g., a populated but
>   empty environment variable could cause weird behavior).
> * Preferring optional chaining over chaining with the `&&` operator.
> * Using dot navigation over index navigation.
> 
> I also added type declaration files back into scope for linting with
> some more specific disables for cases where the lint failures are forced
> by compatibility with the upstream library.

I think the nullish coalescing preference is probably the most controversial (notably, it's also the one that eslint is unwilling to auto-fix, although if you have LSP/editor integration, there is an autofix available). I like it because I like consistency and dislike Javascript's confusing notions of falsiness but opinions certainly may vary.