### PR TITLE
Enable chunk splitting on frontend code and rework asset references

### DIFF
--- a/site/src/frontend/puzzles/types.ts
+++ b/site/src/frontend/puzzles/types.ts
@@ -1,6 +1,7 @@
 import type { FunctionComponent } from "react";
 // Anywhere you see "id" in a type, this is a globally-unique string id known to the backend.
 import type { Condition } from "../../huntdata/types";
+import type { Entrypoint } from "../server/assets";
 // An expression indicating the nature of a dependency.
 
 export type Hint = {
@@ -24,13 +25,10 @@ export type Content = {
   // TODO: figure out what props get passed to this FunctionComponent
   component: FunctionComponent;
 
-  // Scripts that will be injected into the page's <head> when rendered.
-  // Generally, should contain the result of lookupScript(webpackEntryPoint)
-  scripts?: string[];
-
-  // Stylesheets that will be injected into the page's <head> when rendered.
-  // Generally, should contain the result of lookupStylesheet(webpackEntryPoint)
-  stylesheets?: string[];
+  // If present, the scripts and stylesheets produced by the webpack entrypoint
+  // of the given name will be injected into the page's <body> and <head>
+  // respectively.
+  entrypoint?: Entrypoint;
 };
 
 export type PuzzleDefinition = {

--- a/site/src/frontend/rounds/index.ts
+++ b/site/src/frontend/rounds/index.ts
@@ -1,6 +1,6 @@
 import type { FunctionComponent } from "react";
 import type { TeamState } from "../../../lib/api/client";
-import { lookupScript, lookupStylesheet } from "../server/assets";
+import type { Entrypoint } from "../server/assets";
 import BackgroundCheckRoundPage from "./background_check";
 import IllegalSearchRoundPage from "./illegal_search";
 import PapertrailRoundPage from "./papertrail";
@@ -16,15 +16,13 @@ import RealDiamondRoundPage from "./the_real_diamond";
 // TODO: figure out the props we want to pass to the round pages
 type RoundDefinition = {
   component: FunctionComponent<{ teamState: TeamState }>;
-  scripts?: string[];
-  stylesheets?: string[];
+  entrypoint?: Entrypoint;
 };
 
 export const ROUND_PAGE_MAP: Record<string, RoundDefinition> = {
   shadow_diamond: {
     component: ShadowDiamondRoundPage,
-    scripts: [lookupScript("shadow_diamond")],
-    stylesheets: [lookupStylesheet("shadow_diamond")],
+    entrypoint: "shadow_diamond",
   },
   stakeout: {
     component: StakeoutRoundPage,

--- a/site/src/frontend/server/assets.ts
+++ b/site/src/frontend/server/assets.ts
@@ -1,26 +1,14 @@
 // Load manifests
-import cssManifest from "../../../dist/css-manifest.json";
-import jsManifest from "../../../dist/js-manifest.json";
+import entrypointManifest from "../../../dist/js-manifest-with-chunks.json";
 // import assetManifest from "../dist/asset-manifest.json";
+export type Entrypoint = keyof typeof entrypointManifest;
 
-export function lookupScript(entryPointName: string): string {
-  const key = `${entryPointName}.js` as keyof typeof jsManifest;
-  const script = jsManifest[key] as string | undefined;
-  if (script === undefined) {
-    throw new Error(
-      `Could not find ${key} in js-manifest.json (is there a webpack entrypoint with the name ${entryPointName}?)`,
-    );
-  }
-  return script;
+export function lookupScripts(entrypoint: Entrypoint): string[] {
+  const allDeps = entrypointManifest[entrypoint];
+  return allDeps.filter((dep) => dep.endsWith(".js"));
 }
 
-export function lookupStylesheet(entryPointName: string): string {
-  const key = `${entryPointName}.css` as keyof typeof cssManifest;
-  const stylesheet = cssManifest[key] as string | undefined;
-  if (stylesheet === undefined) {
-    throw new Error(
-      `Could not find ${key} in css-manifest.json (is there a webpack entrypoint with the name ${entryPointName}?)`,
-    );
-  }
-  return stylesheet;
+export function lookupStylesheets(entrypoint: Entrypoint): string[] {
+  const allDeps = entrypointManifest[entrypoint];
+  return allDeps.filter((dep) => dep.endsWith(".css"));
 }

--- a/site/src/frontend/server/routes/round.tsx
+++ b/site/src/frontend/server/routes/round.tsx
@@ -2,6 +2,7 @@ import { type Request } from "express";
 import React from "react";
 import Layout from "../../components/Layout";
 import { ROUND_PAGE_MAP } from "../../rounds";
+import { lookupScripts, lookupStylesheets } from "../assets";
 
 export type RoundParams = {
   roundSlug: string;
@@ -20,8 +21,12 @@ export const roundHandler = (req: Request<RoundParams>) => {
     return undefined;
   }
   const Component = content.component;
-  const scripts = content.scripts;
-  const stylesheets = content.stylesheets;
+  const scripts = content.entrypoint
+    ? lookupScripts(content.entrypoint)
+    : undefined;
+  const stylesheets = content.entrypoint
+    ? lookupStylesheets(content.entrypoint)
+    : undefined;
 
   // TODO: pass props about current unlock state to Component
   return (


### PR DESCRIPTION
This simplifies the integration for puzzles that want to bring their own browser-side scripts or stylesheets.

We now allow specifying a single `entrypoint` on `content`, which if provided will cause us to inject all of the script and stylesheets reached by the webpack entrypoint of the same name.

Additionally, through enabling chunk splitting, we are now able to reuse chunks with various library dependencies across multiple contexts.  This means that we can share the same `react` and `react-dom` across an entrypoint used on all pages, an entrypoint used on all puzzle or round pages, and ones used on puzzle-specific pages, without needing to fetch or parse the deps multiple times.